### PR TITLE
Add support for identifiers nested properties.

### DIFF
--- a/src/filters/parse.rs
+++ b/src/filters/parse.rs
@@ -79,7 +79,7 @@ peg::parser! {
 
         /// Parses an identifier.
         rule identifier() -> String
-            = s:$(['a'..='z'|'A'..='Z'|'_']['a'..='z'|'A'..='Z'|'_'|'0'..='9']+) { s.to_string() }
+            = s:$(['a'..='z'|'A'..='Z'|'_']['a'..='z'|'A'..='Z'|'_'|'0'..='9']*(['.'|'/'] _ identifier())?) { s.to_string() }
 
         /// Parses a value, which can be a string, datetime, date, time, number, boolean, or null.
         rule value() -> Result<Value, ParseError>

--- a/tests/filters_parse.rs
+++ b/tests/filters_parse.rs
@@ -606,3 +606,35 @@ fn multiple_nested_functions() {
         )
     );
 }
+
+#[test]
+fn identifier_nested_properties() {
+    let identifiers = vec![
+        "address/city",
+        "model.address",
+        "address/city/position/longitude",
+        "model.address/city",
+        "model.address.city",
+        "a/_"
+    ];
+
+    for identifier in identifiers {
+        assert_eq!(parse_str(identifier).expect("valid filter tree"), Expr::Identifier(identifier.to_owned()).into());
+    }
+}
+
+#[test]
+fn identifier_invalid_nested_properties() {
+    let identifiers = vec![
+        "address/city.1",
+        "model.address!1",
+        "address/city/position/longitude/",
+        "address/city/position/longitude+a",
+        "address/city/(position/longitude)",
+        "model.address."
+    ];
+    
+    for identifier in identifiers {
+        assert!(parse_str(identifier).is_err());
+    }
+}


### PR DESCRIPTION
Allows the use of nested properties, such as: `address/city`. I also allowed single character identifiers.